### PR TITLE
Docker + eliminación de dep

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+# This Dockerfile is no longer needed for MySQL-only setup.
+# You can remove or ignore this file if you are not containerizing the app itself.
+
+# Use Maven to build the app, then run it with Java
+# FROM maven:3.9.7-eclipse-temurin-21 AS build
+# WORKDIR /app
+# COPY . .
+# RUN mvn clean package -DskipTests
+
+# FROM eclipse-temurin:21-jre
+# WORKDIR /app
+# COPY --from=build /app/target/tp3-desi-0.0.1-SNAPSHOT.war app.war
+# EXPOSE 8080
+# ENTRYPOINT ["java", "-jar", "app.war"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '3.8'
+services:
+  mysql:
+    image: mysql:8
+    container_name: mysql-desitp
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: desitp
+    ports:
+      - "3306:3306"
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    platform: linux/amd64

--- a/pom.xml
+++ b/pom.xml
@@ -67,11 +67,11 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
-		<dependency>
+		<!-- <dependency>
 			<groupId>ar.edu.tuti</groupId>
 			<artifactId>tuti-desi-tp-03</artifactId>
 			<version>0.0.1-SNAPSHOT</version>
-		</dependency>
+		</dependency> -->
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-validation</artifactId>


### PR DESCRIPTION
Deshabilitada la dependencia del snapshot del proyecto (problemas para correr los tests). Agregado un Dockerfile (comentado, pendiente implementar para containerizar la app). Agregado un docker-compose.yml para ejecutar la DB en un container de docker